### PR TITLE
Fix import path

### DIFF
--- a/litreview/asgi.py
+++ b/litreview/asgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'litreview.src.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings')
 
 application = get_asgi_application()

--- a/litreview/src/settings/settings.py
+++ b/litreview/src/settings/settings.py
@@ -23,7 +23,7 @@ MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media/')
 
 # Read secret file
-with open(os.path.join(BASE_DIR, 'settings', '.litreview.secret')) as f:
+with (BASE_DIR / 'settings' / '.litreview.secret').open() as f:
     SECRETS = json.load(f)
 
 SECRET_KEY = SECRETS['SECRET_KEY']
@@ -69,7 +69,7 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
-ROOT_URLCONF = 'litreview.src.web.litreview.urls'
+ROOT_URLCONF = 'litreview.urls'
 
 TEMPLATES = [
     {

--- a/litreview/src/web/litreview/admin.py
+++ b/litreview/src/web/litreview/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
-from litreview.src.web.litreview.models.user import LitUser, UserFollows
-from litreview.src.web.litreview.models.ticket import Ticket
-from litreview.src.web.litreview.models.review import Review
+from litreview.models.user import LitUser, UserFollows
+from litreview.models.ticket import Ticket
+from litreview.models.review import Review
 
 
 # Register your models here.

--- a/litreview/src/web/litreview/models/__init__.py
+++ b/litreview/src/web/litreview/models/__init__.py
@@ -1,3 +1,0 @@
-# from litreview.src.web.models.user import LitUser
-#
-# __all__ = ["LitUser"]

--- a/litreview/src/web/litreview/models/review.py
+++ b/litreview/src/web/litreview/models/review.py
@@ -2,7 +2,7 @@ from django.contrib.auth import get_user_model
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 
-from litreview.src.web.litreview.models.ticket import Ticket
+from litreview.models.ticket import Ticket
 
 
 User = get_user_model()

--- a/litreview/src/web/litreview/urls.py
+++ b/litreview/src/web/litreview/urls.py
@@ -16,7 +16,7 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 
-from litreview.src.web.litreview.views.main import Homepage
+from litreview.views.main import Homepage
 
 urlpatterns = [
     path('admin/', admin.site.urls),

--- a/litreview/src/web/manage.py
+++ b/litreview/src/web/manage.py
@@ -2,11 +2,14 @@
 """Django's command-line utility for administrative tasks."""
 import os
 import sys
+from pathlib import Path
 
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'litreview.src.settings.settings')
+    settings_module = Path(__file__).resolve().parent.parent / "settings"
+    sys.path.insert(0, str(settings_module))
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings')
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/litreview/wsgi.py
+++ b/litreview/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'litreview.src.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings')
 
 application = get_wsgi_application()


### PR DESCRIPTION
Bon !

Après encore quelques recherches j'en suis arrivé à la conclusion que python se débrouillait tout seul pour mettre le dossier contenant `manage.py` dans son path. En revanche, puisque tes settings sont à l'extérieur de ce dossier, il faut l'indiquer (cf fonction `main` de `manage.py`).

À partir de là, tout coule assez bien : on peut importer le module `settings`, et les imports d'apps se font comme tu t'y attends (sans devoir spécifier un long chemin, puisque `web` est une racine de modules).

J'ai corrigé les imports et j'en ai profité pour te suggérer une syntaxe un peu plus agréable pour l'ouverture de ton fichier de secrets.

J'en ai profité pour apprendre au passage que Django se débrouille tout seul pour importer les modèles, pas besoin de les spécifier dans le `__init__.py` visiblement.

Le projet n'est pas encore utilisable en l'état mais il ne reste pas grand chose. Tout se passe dans le module `user`:
* Corriger la définition de `LitUser` pour hériter de `AbstractUser`, supprimer le `app_label` (et la classe `Meta`)
* Faire référence directement à `LitUser` dans les `ForeignKey` de la classe du dessous

Après ça, il sera possible de créer les migrations pour notre app : `python ./litreview/src/web/manage.py makemigrations litreview`. Il faut spécifier l'app explicitement une première fois pour que django crée le package `migrations`, ensuite on pourra l'omettre.

À la semaine prochaine !